### PR TITLE
Update metadata for QGIS plugin

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -1,9 +1,13 @@
 # metadata.txt
 [general]
 name=Brush Selection Tool
-qgisMinimumVersion=3.0
+qgisMinimumVersion=3.28
 description=Brush-style polygon selection tool similar to eCognition
-version=1.0
+about=Brush over polygon features to select those intersecting the stroke.
+ Use a freehand brush to sweep across the map; any polygons touched are selected.
+ Currently limited to polygon geometry layers.
+version=0.1.0
+changelog=0.1.0 - Initial release.
 license=GPL-2.0-or-later
 author=Aman Bagrecha
 email=amanbagrecha.blr@gmail.com
@@ -15,13 +19,13 @@ category=Vector
 tags=selection,brush,polygon,vector
 
 [repository]
-repository=
+repository=https://github.com/amanbagrecha/brush-tool-selection
 
 [tracker]
-tracker=
+tracker=https://github.com/amanbagrecha/brush-tool-selection/issues
 
 [homepage]
-homepage=
+homepage=https://github.com/amanbagrecha/brush-tool-selection
 
 [icon]
 icon=paintbrush.png


### PR DESCRIPTION
## Summary
- add version, changelog, and multi-line about section in metadata
- fill in project links and require QGIS 3.28+
- clarify about section to describe brushing polygons to select intersecting features

## Testing
- `python -m pytest`
- `python -m py_compile brush_selection_plugin.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68be64b32ee08329abc395a1850f4b09