### PR TITLE
Add release workflow and release documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install qgis-plugin-ci
+        run: pip install qgis-plugin-ci
+      - name: Package plugin
+        run: qgis-plugin-ci package
+      - name: Publish to QGIS plugin repository
+        env:
+          OSGEO_USERNAME: ${{ secrets.OSGEO_USERNAME }}
+          OSGEO_PASSWORD: ${{ secrets.OSGEO_PASSWORD }}
+        run: qgis-plugin-ci release ${GITHUB_REF#refs/tags/}

--- a/readme.md
+++ b/readme.md
@@ -28,3 +28,20 @@ This plugin is released under the GPL-2.0-or-later license. See the [LICENSE](LI
 - **QGIS Plugin Development**: Built using QGIS Plugin Builder and Qt Designer
 
 
+## Release
+
+This project uses [qgis-plugin-ci](https://github.com/opengisch/qgis-plugin-ci) to package and publish the plugin.
+
+### Required secrets
+
+The GitHub release workflow requires the following repository secrets:
+
+- `OSGEO_USERNAME` – OSGeo username with permission to publish the plugin.
+- `OSGEO_PASSWORD` – Password for the OSGeo account.
+
+### Procedure
+
+1. Update `metadata.txt` with the new version.
+2. Commit and push your changes.
+3. Create and push a tag for the new version, e.g. `git tag -a 1.0.0 -m "Release 1.0.0"` and `git push origin 1.0.0`.
+4. GitHub Actions will package the plugin and upload it to the QGIS plugin repository.


### PR DESCRIPTION
## Summary
- add GitHub Action workflow to package and publish plugin via qgis-plugin-ci
- document required secrets and release procedure in readme

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68be72ea60548329a1955afa098a028a