### PR TITLE
feat: Add support for all vector geometry types

### DIFF
--- a/BrushSelectionTool/brush_selection_plugin.py
+++ b/BrushSelectionTool/brush_selection_plugin.py
@@ -210,18 +210,11 @@ class BrushSelectionTool(QgsMapTool):
     def _iter_target_layers(self):
         if self.active_layer_only:
             lyr = self.iface.activeLayer()
-            if (
-                lyr
-                and lyr.type() == lyr.VectorLayer
-                and lyr.geometryType() == QgsWkbTypes.PolygonGeometry
-            ):
+            if lyr and lyr.type() == lyr.VectorLayer:
                 yield lyr
             return
         for layer in QgsProject.instance().mapLayers().values():
-            if (
-                layer.type() == layer.VectorLayer
-                and layer.geometryType() == QgsWkbTypes.PolygonGeometry
-            ):
+            if layer.type() == layer.VectorLayer:
                 yield layer
 
     def _select_features(self, geom: QgsGeometry):

--- a/BrushSelectionTool/metadata.txt
+++ b/BrushSelectionTool/metadata.txt
@@ -1,13 +1,13 @@
 [general]
 name=Brush Selection Tool
 qgisMinimumVersion=3.40
-description=Brush-style polygon selection tool with intuitive painting interface
-about=Brush Selection Tool provides an intuitive "painting" interface for selecting polygon features in QGIS. Drag a circular brush across the map canvas—every polygon the brush touches becomes selected.
+description=Brush-style vector selection tool with intuitive painting interface for points, lines, and polygons
+about=Brush Selection Tool provides an intuitive "painting" interface for selecting vector features in QGIS. Drag a circular brush across the map canvas—every feature the brush touches becomes selected. Supports points, lines, polygons, and multipolygons.
 version=0.1.1
 author=Aman Bagrecha
 email=amanbagrecha.blr@gmail.com
 
-tags=selection,brush,polygon,vector,painting
+tags=selection,brush,polygon,vector,painting,point,line,multipolygon
 homepage=https://github.com/amanbagrecha/brush-tool-selection
 tracker=https://github.com/amanbagrecha/brush-tool-selection/issues
 repository=https://github.com/amanbagrecha/brush-tool-selection
@@ -16,7 +16,8 @@ experimental=False
 deprecated=False
 category=Vector
 
-changelog=0.1.1 - Selection behavior improvements
+changelog=0.1.1 - Selection behavior improvements and all geometry types support
+    - Add support for all vector geometry types (points, lines, polygons, multipolygons)
     - Fix selection clearing when no features are found
     - Improve multi-layer selection handling
     - Enhanced shift/add to selection behavior

--- a/readme.md
+++ b/readme.md
@@ -6,12 +6,13 @@
 [![License: GPL v2+](https://img.shields.io/badge/License-GPL%20v2%2B-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-Brush Selection Tool provides an intuitive "painting" interface for selecting polygon features in QGIS.  
-Drag a circular brush across the map canvas—every polygon the brush touches becomes selected.
+Brush Selection Tool provides an intuitive "painting" interface for selecting vector features in QGIS.
+Drag a circular brush across the map canvas—every feature the brush touches becomes selected. Works with points, lines, polygons, and multipolygons.
 
 ---
 
 ## Features
+- **Supports all vector geometry types**: points, lines, polygons, and multipolygons
 - Adjustable pixel-based brush radius (1–200 px) for consistent behavior across all projections
 - Real‑time visual feedback: translucent cursor circle and brush‑stroke rubber band
 - Choose to add to existing selections or replace them
@@ -38,11 +39,12 @@ Drag a circular brush across the map canvas—every polygon the brush touches be
 
 ## Usage
 1. Activate the tool from the toolbar icon (paintbrush icon).
-2. Click and drag with the left mouse button to "paint" over polygons.
+2. Click and drag with the left mouse button to "paint" over features.
 3. Release the mouse button to finalize the selection.
 4. **Controls:**
    - **Shift + Mouse Wheel**: Adjust brush radius (1–200 px) in real-time
    - **Shift + Click/Drag**: Add to existing selection instead of replacing
+5. **Note:** Works on the active layer by default. Supports all vector geometry types (points, lines, polygons, multipolygons).
 
 
 ## Demo


### PR DESCRIPTION
## Summary
- Removed polygon-only geometry restriction to enable selection of all vector types (points, lines, polygons, multipolygons)
- Updated plugin metadata and README to reflect expanded geometry support
- Enhanced plugin description and tags for better discoverability

## Changes
- **Code**: Removed `QgsWkbTypes.PolygonGeometry` checks in `_iter_target_layers()` method
- **Metadata**: Updated description, about text, tags, and changelog to reflect all geometry type support
- **Documentation**: Updated README features, usage instructions, and descriptions

## Test plan
- [x] Test brush selection on point layers
- [x] Test brush selection on line layers  
- [ ] Test brush selection on polygon layers
- [ ] Test brush selection on multipolygon layers
- [ ] Verify shift+drag adds to selection for all geometry types
- [ ] Confirm brush radius adjustment works consistently across geometry types
- [ ] Test with active layer only mode
- [ ] Test with all layers mode
