### PR TITLE
Document QGIS publishing steps

### DIFF
--- a/BrushSelectionTool/metadata.txt
+++ b/BrushSelectionTool/metadata.txt
@@ -3,7 +3,7 @@ name=Brush Selection Tool
 qgisMinimumVersion=3.40
 description=Brush-style vector selection tool with intuitive painting interface for points, lines, and polygons
 about=Brush Selection Tool provides an intuitive "painting" interface for selecting vector features in QGIS. Drag a circular brush across the map canvas—every feature the brush touches becomes selected. Supports points, lines, polygons, and multipolygons.
-version=0.1.1
+version=0.1.2
 author=Aman Bagrecha
 email=amanbagrecha.blr@gmail.com
 
@@ -16,7 +16,10 @@ experimental=False
 deprecated=False
 category=Vector
 
-changelog=0.1.1 - Selection behavior improvements and all geometry types support
+changelog=0.1.2 - Renderer-aware selection update
+    - Respect renderer visibility when selecting (e.g., hidden categories or disabled rules)
+    - Refresh release instructions for tagging and publishing
+    0.1.1 - Selection behavior improvements and all geometry types support
     - Add support for all vector geometry types (points, lines, polygons, multipolygons)
     - Fix selection clearing when no features are found
     - Improve multi-layer selection handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "brush-tool-selection"
 description = "QGIS plugin for brush-based feature selection"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.9"
 dependencies = [
     "ruff>=0.13.1",

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ See the `changelog` entry in [metadata.txt](metadata.txt) for version history.
 ---
 
 ## Release
-This project uses [qgis-plugin-ci](https://github.com/opengisch/qgis-plugin-ci) to package and publish the plugin.
+This project uses [qgis-plugin-ci](https://github.com/opengisch/qgis-plugin-ci) and a GitHub Actions workflow to package and publish new versions to the QGIS Plugin Repository.
 
 ### Required secrets
 The GitHub release workflow requires the following repository secrets:
@@ -90,9 +90,18 @@ The GitHub release workflow requires the following repository secrets:
 - `OSGEO_USERNAME` – OSGeo username with permission to publish the plugin
 - `OSGEO_PASSWORD` – Password for the OSGeo account
 
-### Procedure
-1. Update `metadata.txt` with a new version number.
-2. Commit and push your changes.
-3. Create and push a tag for the new version, e.g. `git tag -a 1.0.0 -m "Release 1.0.0"` and `git push origin 1.0.0`.
-4. GitHub Actions packages the plugin and uploads it to the QGIS Plugin Repository.
+### Publishing procedure
+1. Update `metadata.txt` with the new version number and changelog entry.
+2. Merge the release branch into `main`.
+3. Sync your local `main` branch:
+   ```bash
+   git checkout main
+   git pull
+   ```
+4. Create and push a tag for the new version (the CI workflow listens for tags):
+   ```bash
+   git tag -a 0.1.2 -m "Release 0.1.2"
+   git push origin 0.1.2
+   ```
+5. GitHub Actions builds the plugin with `qgis-plugin-ci` and publishes it to the QGIS Plugin Repository.
 


### PR DESCRIPTION
## Summary
- explain the qgis-plugin-ci/GitHub Actions process for publishing to the QGIS Plugin Repository
- add step-by-step tagging instructions for releasing version 0.1.2

## Testing
- not run (not requested)

## Release steps
- after merging: `git checkout main && git pull`
- create the tag: `git tag -a 0.1.2 -m "Release 0.1.2" && git push origin 0.1.2`
- the GitHub Action will build and publish the plugin to the QGIS Plugin Repository via qgis-plugin-ci


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416fab04fc8329b532f2095f10c538)