### PR TITLE
fix: transform stroke geometry to layer CRS before selection

### DIFF
--- a/BrushSelectionTool/brush_selection_plugin.py
+++ b/BrushSelectionTool/brush_selection_plugin.py
@@ -1,6 +1,7 @@
 import os
 
 from qgis.core import (
+    QgsCoordinateTransform,
     QgsFeatureRequest,
     QgsGeometry,
     QgsPointXY,
@@ -219,7 +220,7 @@ class BrushSelectionTool(QgsMapTool):
                 yield layer
 
     def _select_features(self, geom: QgsGeometry):
-        bbox = geom.boundingBox()
+        canvas_crs = self.canvas.mapSettings().destinationCrs()
         total = 0
         layer_counts = []
 
@@ -228,11 +229,18 @@ class BrushSelectionTool(QgsMapTool):
         timer.start()
 
         for layer in self._iter_target_layers():
+            layer_crs = layer.crs()
+            if canvas_crs != layer_crs:
+                transform = QgsCoordinateTransform(canvas_crs, layer_crs, QgsProject.instance())
+                layer_geom = QgsGeometry(geom)
+                layer_geom.transform(transform)
+            else:
+                layer_geom = geom
+
+            bbox = layer_geom.boundingBox()
             req = QgsFeatureRequest().setFilterRect(bbox).setSubsetOfAttributes([])
-            # Respect layer's subset string (filter) - only iterate through filtered features
             req.setFlags(QgsFeatureRequest.NoFlags)
 
-            # Set up renderer context to check feature visibility
             renderer = layer.renderer().clone()
             context = QgsRenderContext()
             context.setExpressionContext(layer.createExpressionContext())
@@ -243,8 +251,7 @@ class BrushSelectionTool(QgsMapTool):
                 fgeom = feat.geometry()
                 if not fgeom or fgeom.isEmpty():
                     continue
-                if fgeom.intersects(geom):
-                    # Check if feature would actually be rendered (respects categorized symbology visibility)
+                if fgeom.intersects(layer_geom):
                     context.expressionContext().setFeature(feat)
                     if renderer.willRenderFeature(feat, context):
                         ids.append(feat.id())


### PR DESCRIPTION
## Summary
- Brush selection failed silently when a Google (or any Web Mercator) basemap was loaded, because QGIS sets the canvas CRS to EPSG:3857 while vector layers may be in a different CRS (e.g. EPSG:4326)
- The stroke geometry and bounding box were in canvas CRS but `setFilterRect` and `intersects` both operate in the layer's native CRS, so coordinates never matched
- Fix: transform the stroke geometry into each target layer's CRS before the bbox filter and intersection test

## Test plan
- [ ] Load a vector layer (EPSG:4326 or any non-3857 CRS)
- [ ] Add a Google basemap via QuickMapServices (forces canvas to EPSG:3857)
- [ ] Make the vector layer active in the Layers panel
- [ ] Use the brush selection tool — features should now be selected correctly
- [ ] Verify selection still works without any basemap (same-CRS path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)